### PR TITLE
Replaced problematic characters fixing "This option is not available"

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -109,8 +109,8 @@ main() {
         extras=$(zenity --title "DeckSight" --list --checklist \
             --width=500 --height=420 \
             --text="Choose which components to $action:\n\n\
-    • Gamescope Script – framerate handling and modesetting in gamescope.\n\
-    • DeckSight EDID – Extended EDID for HDR support." \
+    * Gamescope Script - framerate handling and modesetting in gamescope.\n\
+    * DeckSight EDID - Extended EDID for HDR support." \
             --column "Apply" --column "Component" \
             TRUE "Gamescope Script" \
             TRUE "DeckSight EDID") || exit 0
@@ -118,9 +118,9 @@ main() {
         extras=$(zenity --title "DeckSight" --list --checklist \
             --width=500 --height=480 \
             --text="Choose which components to $action:\n\n\
-    • Gamescope Script – framerate handling and modesetting in gamescope.\n\
-    • Brightness Wrangler – Gamma-based brightness control service.(X11/SteamOS only)\n\
-    • DeckSight EDID – Extended EDID for HDR support." \
+    * Gamescope Script - framerate handling and modesetting in gamescope.\n\
+    * Brightness Wrangler - Gamma-based brightness control service.(X11/SteamOS only)\n\
+    * DeckSight EDID - Extended EDID for HDR support." \
             --column "Apply" --column "Component" \
             TRUE "Gamescope Script" \
             TRUE "Brightness Wrangler" \


### PR DESCRIPTION
Hi, 

first of all thanks for all the work on the DeckSight screen, can't wait to finish the installation!

On Steam OS, I noticed an issue while trying to use the DeckSight.desktop.download, where I could not get past the "Install Extras Screen". In my case, selecting "Install" and "Ok" would close the whole program. 

After some investigation, I found that the install.sh script seems to have some characters, that causes it to close with "This option is not available": 

<img width="1505" height="548" alt="error_message" src="https://github.com/user-attachments/assets/3669fb3a-4a1e-42a7-996e-e545f3403a4f" />

<img width="1620" height="795" alt="invalid_characters" src="https://github.com/user-attachments/assets/7dbef521-37c3-4e12-81cc-273015a67bf5" />


Replacing these characters with simple ones fixed it for me, so I thought I might share this here